### PR TITLE
Fix: Improve readability of schedule error messages

### DIFF
--- a/api/internal/worker/handlers/invhandlers/schedsingle.go
+++ b/api/internal/worker/handlers/invhandlers/schedsingle.go
@@ -472,7 +472,7 @@ func openapiToGrpcSingleSchedSeconds(body *api.SingleSchedule, sched *schedv1.Si
 	if body.EndSeconds != nil && body.StartSeconds != 0 {
 		if sched.EndSeconds < sched.StartSeconds {
 			err := errors.Errorfc(codes.InvalidArgument,
-				"end_seconds must be equal or bigger than start_seconds")
+				"The schedule end time must be greater than the start time")
 			log.InfraErr(err).Msg("error in specified values of end_seconds and start_seconds")
 			return err
 		}


### PR DESCRIPTION
### Description

Improve readability of error messages when end time created before start time.

### How Has This Been Tested?

Is only a change in the error message, should have no test impact.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes
- [X] I have not introduced any 3rd party dependency changes
- [X] I have performed a self-review of my code
