### PR TITLE
Adds buffer to inventory client events chan

### DIFF
--- a/inventory/pkg/client/cache/schedule/schedule_cache.go
+++ b/inventory/pkg/client/cache/schedule/schedule_cache.go
@@ -50,6 +50,9 @@ const (
 	defaultListAllTimeout   = time.Minute
 
 	defaultRegisterMaxElapsedTime = 30 * time.Second
+
+	// eventsWatcherBufSize is the buffer size for the events channel.
+	eventsWatcherBufSize = 10
 )
 
 type cacheKey struct {
@@ -190,7 +193,7 @@ func NewScheduleCacheClientWithOptions(
 	opts ...Option,
 ) (*ScheduleCacheClient, error) {
 	var wg sync.WaitGroup
-	eventsWatcher := make(chan *client.WatchEvents)
+	eventsWatcher := make(chan *client.WatchEvents, eventsWatcherBufSize)
 
 	var options Options
 	options.RegisterMaxElapsedTime = defaultRegisterMaxElapsedTime

--- a/tenant-controller/internal/invclient/invclient.go
+++ b/tenant-controller/internal/invclient/invclient.go
@@ -22,6 +22,9 @@ var (
 		inv_v1.ResourceKind_RESOURCE_KIND_TENANT,
 		inv_v1.ResourceKind_RESOURCE_KIND_WORKLOAD,
 	}
+
+	// eventsWatcherBufSize is the buffer size for the events channel.
+	eventsWatcherBufSize = 10
 )
 
 type TCInventoryClient struct {
@@ -73,7 +76,7 @@ func NewInventoryClientWithOptions(
 		opt(&options)
 	}
 
-	eventsWatcher := make(chan *client.WatchEvents)
+	eventsWatcher := make(chan *client.WatchEvents, eventsWatcherBufSize)
 
 	cfg := client.InventoryClientConfig{
 		Name:                      clientName,


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### Description

Adds default buffer (size `10`) to the inventory clients in `inventory/client/cache`, tenantController, exporter. API makes no usage of subscriptions, so it's not needed.
Also, it sets minor improvements in exporter timeouts for scale considerations.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
