### PR TITLE
fix: allow auto-release with and without v in the tag

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -8,7 +8,7 @@ name: "Release subfolder-specific notes via GitHub API"
 on:
   push:
     tags:
-      - '*/*'   # matches tags containing '/', e.g. "component/v1.2.3"
+      - '*/*'   # matches tags containing '/', e.g. "component/v1.2.3" or "component/1.2.3"
 
 permissions:
   contents: write  # needed to create/update releases
@@ -34,8 +34,8 @@ jobs:
           SUBFOLDER="${TAG_FULL%%/*}"
           VERSION_PART="${TAG_FULL#*/}"
           # Validate version starts with 'v' followed by digit
-          if [[ ! "$VERSION_PART" =~ ^v[0-9] ]]; then
-            echo "ERROR: Version '$VERSION_PART' does not start with 'v' and digit(s) (e.g. v1.2.3)."
+          if [[ ! "$VERSION_PART" =~ ^(v)?[0-9] ]]; then
+            echo "ERROR: Version '$VERSION_PART' must start with an optional v followed by digits (e.g. v1.2.3 or 1.2.3)."
             exit 1
           fi
           echo "subfolder=$SUBFOLDER"


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### Description

Fix auto-release job to allow tag without `v` too.

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
