### PR TITLE
Remove leftover api and bulk-import-tools projects build instructions from the main Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-SUBPROJECTS := api apiv2 bulk-import-tools tenant-controller exporters-inventory inventory
+SUBPROJECTS := apiv2 tenant-controller exporters-inventory inventory
 
 .DEFAULT_GOAL := help
 .PHONY: all build clean clean-all help lint test
@@ -41,7 +41,7 @@ license: $(VENV_DIR) ## Check licensing with the reuse tool
 build: ## build in all subprojects
 	for dir in $(SUBPROJECTS); do $(MAKE) -C $$dir build; done
 
-DOCKER_PROJECTS := api apiv2 exporters-inventory inventory tenant-controller
+DOCKER_PROJECTS := apiv2 exporters-inventory inventory tenant-controller
 docker-build: ## build all docker containers
 	for dir in $(DOCKER_PROJECTS); do $(MAKE) -C $$dir $@; done
 
@@ -61,12 +61,6 @@ clean: ## clean in all subprojects
 clean-all: ## clean-all in all subprojects
 	for dir in $(SUBPROJECTS); do $(MAKE) -C $$dir clean-all; done
 	rm -rf $(VENV_DIR)
-
-api-%: ## Run api subproject's tasks, e.g. api-test
-	$(MAKE) -C api $*
-
-bit-%: ## Run bulk-import-tools subproject's tasks, e.g. bit-test
-	$(MAKE) -C bulk-import-tools $*
 
 einv-%: ## Run exporters-inventory subproject's tasks, e.g. einv-test
 	$(MAKE) -C exporters-inventory $*

--- a/apiv2/Dockerfile
+++ b/apiv2/Dockerfile
@@ -1,4 +1,5 @@
-# SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+#
 # SPDX-License-Identifier: Apache-2.0
 
 FROM golang:1.25.7-bookworm@sha256:38342f3e7a504bf1efad858c18e771f84b66dc0b363add7a57c9a0bbb6cf7b12 AS build

--- a/exporters-inventory/Dockerfile
+++ b/exporters-inventory/Dockerfile
@@ -1,7 +1,8 @@
-# SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+#
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.25.7-bookworm@sha256:38342f3e7a504bf1efad858c18e771f84b66dc0b363add7a57c9a0bbb6cf7b12 as build
+FROM golang:1.25.7-bookworm@sha256:38342f3e7a504bf1efad858c18e771f84b66dc0b363add7a57c9a0bbb6cf7b12 AS build
 
 ENV GO111MODULE=on
 ARG MAKE_TARGET=go-build

--- a/inventory/Dockerfile
+++ b/inventory/Dockerfile
@@ -1,7 +1,8 @@
-# SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+#
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.25.7-bookworm@sha256:38342f3e7a504bf1efad858c18e771f84b66dc0b363add7a57c9a0bbb6cf7b12 as build
+FROM golang:1.25.7-bookworm@sha256:38342f3e7a504bf1efad858c18e771f84b66dc0b363add7a57c9a0bbb6cf7b12 AS build
 ARG OPA_VERSION
 ARG OPA_SHA
 ARG ATLAS_VERSION

--- a/tenant-controller/Dockerfile
+++ b/tenant-controller/Dockerfile
@@ -1,7 +1,8 @@
-# SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+#
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.25.7-bookworm@sha256:38342f3e7a504bf1efad858c18e771f84b66dc0b363add7a57c9a0bbb6cf7b12 as build
+FROM golang:1.25.7-bookworm@sha256:38342f3e7a504bf1efad858c18e771f84b66dc0b363add7a57c9a0bbb6cf7b12 AS build
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### Description

This PR removes leftover build instructions in the main Makefile for building the `api` and `bulk-import-tools` projects, which were removed from the repository in this PR: https://github.com/open-edge-platform/infra-core/pull/655


Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci and locally

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
