### PR TITLE
Fixing cooldown issue in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -29,6 +31,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -46,6 +50,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -63,6 +69,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -80,6 +88,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -98,3 +108,5 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to introduce a cooldown period for Dependabot updates across multiple package ecosystems. The cooldown setting ensures that Dependabot will wait seven days before opening new pull requests for the same dependency, which helps reduce noise from frequent update PRs.

Dependabot configuration improvements:

* Added a `cooldown` section with `default-days: 7` to each `updates` entry for the following package managers: `gomod`, `npm`, `docker`, `github-actions`, and `pip`, ensuring a 7-day interval between PRs for the same dependency. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R15-R16) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R34-R35) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R53-R54) [[4]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R72-R73) [[5]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R91-R92) [[6]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R111-R112)