### PR TITLE
Update workflows to remove outdated orch-ci ref

### DIFF
--- a/.github/workflows/post-merge-apiv2.yml
+++ b/.github/workflows/post-merge-apiv2.yml
@@ -23,7 +23,6 @@ jobs:
       actions: read
     uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@485a15a77fd03f74e95def2efb568e380cf5fd84  # 2026.1.3
     with:
-      orch_ci_repo_ref: 485a15a77fd03f74e95def2efb568e380cf5fd84
       bootstrap_tools: "all,golangci-lint2"
       run_version_check: true
       run_dep_version_check: true

--- a/.github/workflows/post-merge-exporters-inventory.yml
+++ b/.github/workflows/post-merge-exporters-inventory.yml
@@ -23,7 +23,6 @@ jobs:
       actions: read
     uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@485a15a77fd03f74e95def2efb568e380cf5fd84  # 2026.1.3
     with:
-      orch_ci_repo_ref: 485a15a77fd03f74e95def2efb568e380cf5fd84
       bootstrap_tools: "all,golangci-lint2"
       run_version_check: true
       run_dep_version_check: true

--- a/.github/workflows/post-merge-inventory.yml
+++ b/.github/workflows/post-merge-inventory.yml
@@ -23,7 +23,6 @@ jobs:
       actions: read
     uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@485a15a77fd03f74e95def2efb568e380cf5fd84  # 2026.1.3
     with:
-      orch_ci_repo_ref: 485a15a77fd03f74e95def2efb568e380cf5fd84
       bootstrap_tools: "all,golangci-lint2"
       run_version_check: true
       run_dep_version_check: true

--- a/.github/workflows/post-merge-tenant-controller.yml
+++ b/.github/workflows/post-merge-tenant-controller.yml
@@ -23,7 +23,6 @@ jobs:
       actions: read
     uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@485a15a77fd03f74e95def2efb568e380cf5fd84  # 2026.1.3
     with:
-      orch_ci_repo_ref: 485a15a77fd03f74e95def2efb568e380cf5fd84
       bootstrap_tools: "all,golangci-lint2"
       run_version_check: true
       run_dep_version_check: true


### PR DESCRIPTION
This pull request removes the redundant `orch_ci_repo_ref` input from several GitHub Actions workflow files. This input is no longer necessary because the referenced reusable workflow (`post-merge.yml`) now infers the repository reference from context, simplifying workflow configuration and reducing maintenance overhead.

**Workflow configuration cleanup:**

* [`.github/workflows/post-merge-apiv2.yml`](diffhunk://#diff-ce1bae6493f111a2abc1156c14ea6b0370141c1316573aec8969fc2a533ef609L26): Removed the `orch_ci_repo_ref` input from the workflow dispatch configuration.
* [`.github/workflows/post-merge-exporters-inventory.yml`](diffhunk://#diff-be12fcd954fb76439cb8f3ed4019b673a03846a4d010bd1bcd49a12005a0becbL26): Removed the `orch_ci_repo_ref` input from the workflow dispatch configuration.
* [`.github/workflows/post-merge-inventory.yml`](diffhunk://#diff-82ccf8334c9c02f3b84e34831e59b3ae0a3d2f32c3ba6769ce627a052b843447L26): Removed the `orch_ci_repo_ref` input from the workflow dispatch configuration.
* [`.github/workflows/post-merge-tenant-controller.yml`](diffhunk://#diff-05d2e0ba91f001944e2e34262852154378fbcd6fb05f1e9196602b66a112fc9fL26): Removed the `orch_ci_repo_ref` input from the workflow dispatch configuration.