### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge-apiv2.yml
+++ b/.github/workflows/post-merge-apiv2.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - 'apiv2/**'
+    tags:
+      - '*'
 
 permissions: {}
 

--- a/.github/workflows/post-merge-exporters-inventory.yml
+++ b/.github/workflows/post-merge-exporters-inventory.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - 'exporters-inventory/**'
+    tags:
+      - '*'
 
 permissions: {}
 

--- a/.github/workflows/post-merge-inventory.yml
+++ b/.github/workflows/post-merge-inventory.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - 'inventory/**'
+    tags:
+      - '*'
 
 permissions: {}
 

--- a/.github/workflows/post-merge-os-profiles.yml
+++ b/.github/workflows/post-merge-os-profiles.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - 'os-profiles/**'
+    tags:
+      - '*'
 
 permissions: {}
 

--- a/.github/workflows/post-merge-tenant-controller.yml
+++ b/.github/workflows/post-merge-tenant-controller.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - 'tenant-controller/**'
+    tags:
+      - '*'
 
 permissions: {}
 


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to trigger on tag pushes in addition to the existing branch and path filters. This ensures that the workflows will also run when a new tag is pushed, improving automation coverage for tagged releases.

Trigger enhancements for workflows:

* Added support for triggering workflows on tag pushes (all tags) by including the `tags` filter in the `on:` section of the following workflow files:
  - `.github/workflows/post-merge-apiv2.yml`
  - `.github/workflows/post-merge-exporters-inventory.yml`
  - `.github/workflows/post-merge-inventory.yml`
  - `.github/workflows/post-merge-os-profiles.yml`
  - `.github/workflows/post-merge-tenant-controller.yml`
