### PR TITLE
Remove trigger on tag from post-merge workflows

### DIFF
--- a/.github/workflows/post-merge-apiv2.yml
+++ b/.github/workflows/post-merge-apiv2.yml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - 'apiv2/**'
-    tags:
-      - '*'
 
 permissions: {}
 

--- a/.github/workflows/post-merge-exporters-inventory.yml
+++ b/.github/workflows/post-merge-exporters-inventory.yml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - 'exporters-inventory/**'
-    tags:
-      - '*'
 
 permissions: {}
 

--- a/.github/workflows/post-merge-inventory.yml
+++ b/.github/workflows/post-merge-inventory.yml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - 'inventory/**'
-    tags:
-      - '*'
 
 permissions: {}
 

--- a/.github/workflows/post-merge-os-profiles.yml
+++ b/.github/workflows/post-merge-os-profiles.yml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - 'os-profiles/**'
-    tags:
-      - '*'
 
 permissions: {}
 

--- a/.github/workflows/post-merge-tenant-controller.yml
+++ b/.github/workflows/post-merge-tenant-controller.yml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - 'tenant-controller/**'
-    tags:
-      - '*'
 
 permissions: {}
 


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files by removing the `tags` trigger from their workflow definitions. This change ensures that these workflows will no longer run on tag events, but only on the specified branch and path conditions.

Workflow trigger changes:

* Removed the `tags` trigger from the `on:` section in the following workflow files, so these workflows will no longer run on tag creation or updates:
  - `.github/workflows/post-merge-apiv2.yml`
  - `.github/workflows/post-merge-exporters-inventory.yml`
  - `.github/workflows/post-merge-inventory.yml`
  - `.github/workflows/post-merge-os-profiles.yml`
  - `.github/workflows/post-merge-tenant-controller.yml`