### PR TITLE
Add new workflow security-scan-on-tag.yml

### DIFF
--- a/.github/workflows/security-scan-on-tag.yml
+++ b/.github/workflows/security-scan-on-tag.yml
@@ -1,0 +1,31 @@
+---
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+name: Security scan on tag
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '*'
+permissions:
+  contents: read
+
+jobs:
+  post-merge-pipeline:
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read
+    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@e1be8f090e3bb60af180bfac5ca32638517f9d1f
+    with:
+      run_build: false
+      run_version_tag: false
+      run_repo_pipeline: false
+    secrets:
+      SYS_EMF_GH_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}
+      NO_AUTH_ECR_PUSH_USERNAME: ${{ secrets.NO_AUTH_ECR_PUSH_USERNAME }}
+      NO_AUTH_ECR_PUSH_PASSWD: ${{ secrets.NO_AUTH_ECR_PUSH_PASSWD }}
+      MSTEAMS_WEBHOOK: ${{ secrets.TEAMS_WEBHOOK }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate security scans whenever a new tag is pushed or the workflow is manually triggered. The workflow leverages a reusable workflow from another repository and is configured with the necessary permissions and secrets.

**New security scanning workflow:**

* Added `.github/workflows/security-scan-on-tag.yml` to trigger a security scan job on tag pushes or manual dispatch, using a reusable workflow from `open-edge-platform/orch-ci`. The workflow is configured with appropriate permissions and passes required secrets for authentication and notifications.